### PR TITLE
Nix Permission Fix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -79,7 +79,11 @@ in
     users.users.${cfg.user} = {
       description = "Bitbucket Runner Linux Shell User";
       group = cfg.group;
-      isSystemUser = true;
+      # For certain File System actions, the runner may need an actual user
+      # An example is Nix operations (eg Colmena, deploy-rs etc)
+      isNormalUser = true;
+      createHome = true;
+      home = "/home/${cfg.user}";
     };
 
     users.groups.${cfg.group} = { };


### PR DESCRIPTION
Fixes issue where nix operations such as colmena and deploy rs when invoking nix run would fail on the pipeline runner with errors such as:

`error: creating directory '/nix/var/profiles': Read-only file system`

`error: creating directory '/var/empty/.cache/nix': Operation not permitted`.

This only works when the user responsible for the bitbucket-runner service is able to operate out of it's own directory instead of /tmp