### PR TITLE
Fix broken cloning.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,21 +14,9 @@
       system = "x86_64-linux";
     in
     {
-      packages.${system} = with nixpkgs.legacyPackages.${system}.pkgs; {
-        default = import ./package.nix {
-          inherit
-            writeShellScript
-            fetchzip
-            buildFHSEnv
-            ;
-        };
-        bitbucket-runner = import ./package.nix {
-          inherit
-            writeShellScript
-            fetchzip
-            buildFHSEnv
-            ;
-        };
+      packages.${system} = {
+        default = self.outputs.packages.${system}.bitbucket-runner;
+        bitbucket-runner = nixpkgs.legacyPackages.${system}.pkgs.callPackage ./package.nix {};
       };
       nixosModules.bitbucket-runner.imports = [ ./default.nix ];
     };

--- a/package.nix
+++ b/package.nix
@@ -1,7 +1,9 @@
 {
-  writeShellScript,
-  fetchzip,
   buildFHSEnv,
+  fetchzip,
+  retry,
+  writeScriptBin,
+  writeShellScript
 }:
 let
   version = "3.16.0";

--- a/package.nix
+++ b/package.nix
@@ -10,6 +10,13 @@ let
     hash = "sha256-bY5Qz2v6rN0VNL0fYsVjqmKDLjOYn00dFqa8GDeql3Y=";
     stripRoot = false;
   };
+  # the clone script that the runner generates executes a command of the form
+  # retry 6 git clone --branch="BRANCHNAME" -- depth 50 ...
+  # I'm not sure where such a retry script can be found,
+  # so we just adapt a different retry program to do the job.
+  retry-workaround = writeScriptBin "retry" ''
+    exec -- ${retry}/bin/retry --times="$1" -- ''${@:2}
+  '';
 in
 buildFHSEnv {
   name = "bitbucket-runner-linux-shell";
@@ -20,6 +27,8 @@ buildFHSEnv {
       bash
       git
       util-linux
+      nix  # run nix commands as part of pipeline.
+      retry-workaround
     ]);
   runScript = writeShellScript "bitbucket-runner-linux-shell-start" ''
     cd "${src}/bin"


### PR DESCRIPTION
When using this module in nix-shell mode, the cloneScript that the runner.jar puts together tries to invoke "retry 6 git clone..." which breaks because "retry" isn't in the FHSEnv.

I'm not sure where Atlassian found a retry program with an interface like the above, but I got it working by adapting the common retry program.