### PR TITLE
aarch64-linux support; fix extraFlags; support for environment file paths

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -34,7 +34,7 @@ services.bitbucket-runner = {
     pkgs.nodejs
     pkgs.go
     pkgs.gcc
-  ];
+  ]; # Optional
   runners = {
     runner-1 = {
       accountUuid = "YOUR ACCOUNT UUID";

--- a/README.MD
+++ b/README.MD
@@ -39,20 +39,32 @@ services.bitbucket-runner = {
     runner-1 = {
       accountUuid = "YOUR ACCOUNT UUID";
       runnerUuid = "YOUR RUNNER 1 UUID";
-      OAuthClientId = "YOUR OAUTH CLIENT ID";
-      OAuthClientSecret = "YOUR OAUTH CLIENT SECRET";
+      environmentFile = "/run/secrets/bitbucket-runner-1"; # Preferred and secure; managed by agenix/sops-nix
+      OAuthClientId = "YOUR OAUTH CLIENT ID"; # Alternative if not using /run/secrets, insecure, cannot be used in conjunction with `environmentFile`
+      OAuthClientSecret = "YOUR OAUTH CLIENT SECRET"; # Alternative if not using /run/secrets, insecure, cannot be used in conjunction with `environmentFile`
       runtime = "linux-shell";
     };
     runner-2 = {
       accountUuid = "YOUR ACCOUNT UUID";
       runnerUuid = "YOUR RUNNER 2 UUID";
-      OAuthClientId = "YOUR OAUTH CLIENT ID";
-      OAuthClientSecret = "YOUR OAUTH CLIENT SECRET";
+      environmentFile = "/run/secrets/bitbucket-runner-2"; # Preferred and secure; managed by agenix/sops-nix
+      OAuthClientId = "YOUR OAUTH CLIENT ID"; # Alternative if not using /run/secrets, insecure, cannot be used in conjunction with `environmentFile`
+      OAuthClientSecret = "YOUR OAUTH CLIENT SECRET"; # Alternative if not using /run/secrets, insecure, cannot be used in conjunction with `environmentFile`
       runtime = "linux-docker";
     };
   };
 };
 ```
+
+Each `environmentFile` must contain the runner's OAuth credentials in `KEY=VALUE` format:
+
+```
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
+```
+
+Provision these files outside the Nix store using a secrets manager such as [agenix](https://github.com/ryantm/agenix) or [sops-nix](https://github.com/Mic92/sops-nix).
+You cannot use `OAuthClientId` or `OAuthClientSecret` in conjunction with `environmentFile`
 
 ### Invoked via shell
 

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ in
   imports = [ ];
 
   options.services.bitbucket-runner = {
-    enable = mkEnableOption "Enable Bitbucket runner module";
+    enable = mkEnableOption "Bitbucket runner module";
 
     user = mkOption {
       type = types.str;

--- a/default.nix
+++ b/default.nix
@@ -7,76 +7,72 @@
   ...
 }:
 
-with lib;
-
 let
   cfg = config.services.bitbucket-runner;
   bitbucketRunner = pkgs.callPackage ./package.nix { };
 in
 {
-  imports = [ ];
-
   options.services.bitbucket-runner = {
-    enable = mkEnableOption "Bitbucket runner module";
+    enable = lib.mkEnableOption "Bitbucket runner module";
 
-    user = mkOption {
-      type = types.str;
+    user = lib.mkOption {
+      type = lib.types.str;
       default = "bitbucket-runner";
       description = "User to run Bitbucket runners";
     };
 
-    group = mkOption {
-      type = types.str;
+    group = lib.mkOption {
+      type = lib.types.str;
       default = "bitbucket-runner";
       description = "Group for Bitbucket runners";
     };
 
-    extraPackages = mkOption {
-      type = types.listOf types.package;
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
       default = [ ];
       description = "Packages available to runner environments";
     };
 
-    runners = mkOption {
-      type = types.attrsOf (
-        types.submodule {
+    runners = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
           options = {
-            accountUuid = mkOption {
-              type = types.str;
+            accountUuid = lib.mkOption {
+              type = lib.types.str;
               description = "Account UUID";
             };
-            repositoryUuid = mkOption {
-              type = types.nullOr types.str;
+            repositoryUuid = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
               default = null;
               description = "Repository UUID";
             };
-            runnerUuid = mkOption {
-              type = types.str;
+            runnerUuid = lib.mkOption {
+              type = lib.types.str;
               description = "Runner UUID";
             };
-            OAuthClientId = mkOption {
-              type = types.str;
+            OAuthClientId = lib.mkOption {
+              type = lib.types.str;
               description = "OAuth Client ID";
             };
-            OAuthClientSecret = mkOption {
-              type = types.str;
+            OAuthClientSecret = lib.mkOption {
+              type = lib.types.str;
               description = "OAuth Client Secret";
             };
-            workingDirectory = mkOption {
-              type = types.str;
+            workingDirectory = lib.mkOption {
+              type = lib.types.str;
               default = "/tmp";
               description = "Working directory";
             };
-            runtime = mkOption {
-              type = types.enum [
+            runtime = lib.mkOption {
+              type = lib.types.enum [
                 "linux-shell"
                 "linux-docker"
               ];
               default = "linux-shell";
               description = "Runtime environment";
             };
-            extraFlags = mkOption {
-              type = types.str;
+            extraFlags = lib.mkOption {
+              type = lib.types.str;
               default = "";
               description = "Extra flags";
             };
@@ -88,7 +84,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     users.users.${cfg.user} = {
       isNormalUser = true;
       createHome = true;
@@ -111,7 +107,7 @@ in
           "--workingDirectory ${runner.workingDirectory}"
         ] ++ lib.optional (runner.repositoryUuid != null) "--repositoryUuid {${runner.repositoryUuid}}";
       in
-      nameValuePair "bitbucket-runner-${name}" {
+      lib.nameValuePair "bitbucket-runner-${name}" {
         description = "Bitbucket Runner ${name}";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
@@ -123,11 +119,11 @@ in
           Restart = "on-failure";
         };
       }
-    ) (filterAttrs (_: runner: runner.runtime == "linux-shell") cfg.runners);
+    ) (lib.filterAttrs (_: runner: runner.runtime == "linux-shell") cfg.runners);
 
     virtualisation.oci-containers.containers = lib.mapAttrs' (
       name: runner:
-      nameValuePair "bitbucket-runner-${name}" {
+      lib.nameValuePair "bitbucket-runner-${name}" {
         image = "docker-public.packages.atlassian.com/sox/atlassian/bitbucket-pipelines-runner";
         volumes = [ "/tmp:${runner.workingDirectory}" ];
         environment =
@@ -142,7 +138,7 @@ in
             REPOSITORY_UUID = runner.repositoryUuid;
           };
       }
-    ) (filterAttrs (_: runner: runner.runtime == "linux-docker") cfg.runners);
+    ) (lib.filterAttrs (_: runner: runner.runtime == "linux-docker") cfg.runners);
   };
 
 }

--- a/default.nix
+++ b/default.nix
@@ -51,12 +51,28 @@ in
               description = "Runner UUID";
             };
             OAuthClientId = lib.mkOption {
-              type = lib.types.str;
-              description = "OAuth Client ID";
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "OAuth Client ID. Prefer environmentFile to avoid secrets landing in the Nix store.";
             };
             OAuthClientSecret = lib.mkOption {
-              type = lib.types.str;
-              description = "OAuth Client Secret";
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "OAuth Client Secret. Prefer environmentFile to avoid secrets landing in the Nix store.";
+            };
+            environmentFile = lib.mkOption {
+              type = lib.types.nullOr lib.types.path;
+              default = null;
+              description = ''
+                Path to a file containing OAuth credentials in KEY=VALUE format:
+
+                  OAUTH_CLIENT_ID=your-client-id
+                  OAUTH_CLIENT_SECRET=your-client-secret
+
+                Provision this file outside the Nix store using a secrets
+                manager such as agenix or sops-nix. Mutually exclusive with
+                OAuthClientId and OAuthClientSecret.
+              '';
             };
             workingDirectory = lib.mkOption {
               type = lib.types.str;
@@ -85,6 +101,23 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (name: runner: [
+        {
+          assertion =
+            runner.environmentFile != null
+            || (runner.OAuthClientId != null && runner.OAuthClientSecret != null);
+          message = "bitbucket-runner: runner '${name}' must set either environmentFile or both OAuthClientId and OAuthClientSecret.";
+        }
+        {
+          assertion =
+            runner.environmentFile == null
+            || (runner.OAuthClientId == null && runner.OAuthClientSecret == null);
+          message = "bitbucket-runner: runner '${name}' cannot set environmentFile together with OAuthClientId or OAuthClientSecret.";
+        }
+      ]) cfg.runners
+    );
+
     users.users.${cfg.user} = {
       isNormalUser = true;
       createHome = true;
@@ -98,26 +131,44 @@ in
     systemd.services = lib.mapAttrs' (
       name: runner:
       let
-        execArgs = [
-          "--accountUuid {${runner.accountUuid}}"
-          "--runnerUuid {${runner.runnerUuid}}"
-          "--OAuthClientId ${runner.OAuthClientId}"
-          "--OAuthClientSecret ${runner.OAuthClientSecret}"
-          "--runtime ${runner.runtime}"
-          "--workingDirectory ${runner.workingDirectory}"
-        ] ++ lib.optional (runner.repositoryUuid != null) "--repositoryUuid {${runner.repositoryUuid}}";
+        oauthArgs =
+          if runner.environmentFile != null then
+            [
+              "--OAuthClientId $OAUTH_CLIENT_ID"
+              "--OAuthClientSecret $OAUTH_CLIENT_SECRET"
+            ]
+          else
+            [
+              "--OAuthClientId ${runner.OAuthClientId}"
+              "--OAuthClientSecret ${runner.OAuthClientSecret}"
+            ];
+        execArgs =
+          [
+            "--accountUuid {${runner.accountUuid}}"
+            "--runnerUuid {${runner.runnerUuid}}"
+          ]
+          ++ oauthArgs
+          ++ [
+            "--runtime ${runner.runtime}"
+            "--workingDirectory ${runner.workingDirectory}"
+          ]
+          ++ lib.optional (runner.repositoryUuid != null) "--repositoryUuid {${runner.repositoryUuid}}";
       in
       lib.nameValuePair "bitbucket-runner-${name}" {
         description = "Bitbucket Runner ${name}";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         path = cfg.extraPackages;
-        serviceConfig = {
-          ExecStart = "${bitbucketRunner}/bin/bitbucket-runner-linux-shell ${lib.concatStringsSep " " execArgs}";
-          User = cfg.user;
-          Group = cfg.group;
-          Restart = "on-failure";
-        };
+        serviceConfig =
+          {
+            ExecStart = "${bitbucketRunner}/bin/bitbucket-runner-linux-shell ${lib.concatStringsSep " " execArgs}";
+            User = cfg.user;
+            Group = cfg.group;
+            Restart = "on-failure";
+          }
+          // lib.optionalAttrs (runner.environmentFile != null) {
+            EnvironmentFile = runner.environmentFile;
+          };
       }
     ) (lib.filterAttrs (_: runner: runner.runtime == "linux-shell") cfg.runners);
 
@@ -126,13 +177,16 @@ in
       lib.nameValuePair "bitbucket-runner-${name}" {
         image = "docker-public.packages.atlassian.com/sox/atlassian/bitbucket-pipelines-runner";
         volumes = [ "/tmp:${runner.workingDirectory}" ];
+        environmentFiles = lib.optional (runner.environmentFile != null) runner.environmentFile;
         environment =
           {
             ACCOUNT_UUID = runner.accountUuid;
             RUNNER_UUID = runner.runnerUuid;
+            WORKING_DIRECTORY = runner.workingDirectory;
+          }
+          // lib.optionalAttrs (runner.OAuthClientId != null) {
             OAUTH_CLIENT_ID = runner.OAuthClientId;
             OAUTH_CLIENT_SECRET = runner.OAuthClientSecret;
-            WORKING_DIRECTORY = runner.workingDirectory;
           }
           // lib.optionalAttrs (runner.repositoryUuid != null) {
             REPOSITORY_UUID = runner.repositoryUuid;

--- a/default.nix
+++ b/default.nix
@@ -152,7 +152,8 @@ in
             "--runtime ${runner.runtime}"
             "--workingDirectory ${runner.workingDirectory}"
           ]
-          ++ lib.optional (runner.repositoryUuid != null) "--repositoryUuid {${runner.repositoryUuid}}";
+          ++ lib.optional (runner.repositoryUuid != null) "--repositoryUuid {${runner.repositoryUuid}}"
+          ++ lib.optional (runner.extraFlags != "") runner.extraFlags;
       in
       lib.nameValuePair "bitbucket-runner-${name}" {
         description = "Bitbucket Runner ${name}";

--- a/default.nix
+++ b/default.nix
@@ -185,7 +185,7 @@ in
             RUNNER_UUID = runner.runnerUuid;
             WORKING_DIRECTORY = runner.workingDirectory;
           }
-          // lib.optionalAttrs (runner.OAuthClientId != null) {
+          // lib.optionalAttrs (runner.OAuthClientId != null && runner.OAuthClientSecret != null) {
             OAUTH_CLIENT_ID = runner.OAuthClientId;
             OAUTH_CLIENT_SECRET = runner.OAuthClientSecret;
           }

--- a/flake.nix
+++ b/flake.nix
@@ -9,20 +9,25 @@
       nixpkgs,
     }:
     let
-      system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
-      packages.${system} = {
+      packages = forAllSystems (system: {
         default = self.outputs.packages.${system}.bitbucket-runner;
-        bitbucket-runner = pkgs.callPackage ./package.nix { };
-      };
-      devShells.${system}.default = pkgs.mkShell {
-        packages = [
-          pkgs.nix-update
-          pkgs.git
-        ];
-      };
+        bitbucket-runner = nixpkgs.legacyPackages.${system}.callPackage ./package.nix { };
+      });
+      devShells = forAllSystems (system: {
+        default = nixpkgs.legacyPackages.${system}.mkShell {
+          packages = [
+            nixpkgs.legacyPackages.${system}.nix-update
+            nixpkgs.legacyPackages.${system}.git
+          ];
+        };
+      });
       nixosModules.bitbucket-runner.imports = [ ./default.nix ];
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     }:
     let
       system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system}.pkgs;
+      pkgs = nixpkgs.legacyPackages.${system};
     in
     {
       packages.${system} = {


### PR DESCRIPTION
extraFlags previously was never actually integrated
x86_64-linux was hardcoded as a supported system despite aarch64-linux being supported by the linux-shell runner
previously only insecure hardcoded secrets were supported, now an environment file can be specified per runner