### PR TITLE
fix: UnsupportedClassVersionError with runner v6

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -27,7 +27,7 @@ buildFHSEnv {
   targetPkgs =
     pkgs:
     (with pkgs; [
-      jre
+      jdk25
       bash
       git
       util-linux


### PR DESCRIPTION
Runner v6 JARs are compiled at class file version 69 (Java 25). The FHS environment was providing `jre` which resolves to Java 21, causing the service to fail on startup with:

```
java.lang.UnsupportedClassVersionError: com/atlassian/pipelines/runner/core/ApplicationImpl has been compiled by a more recent version of the Java Runtime than version X of the JVM
Error: LinkageError occurred while loading main class com.atlassian.pipelines.runner.core.ApplicationImpl
```

`jdk25` is used over `jre25_minimal` as the minimal variant strips the `java.xml` module via `jlink`, which the runner loads at runtime through logback:

```
Caused by: java.lang.ClassNotFoundException: org.xml.sax.InputSource
Exception in thread "main" java.lang.NoClassDefFoundError: org/xml/sax/InputSource
```